### PR TITLE
Examples/sdl2 improvement

### DIFF
--- a/examples/sdl2/main.go
+++ b/examples/sdl2/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"image"
 	"log"
+	"time"
 
 	"github.com/hakobera/go-ayame/ayame"
 	"github.com/hakobera/go-ayame/pkg/vpx"
@@ -149,5 +150,6 @@ func main() {
 				break
 			}
 		}
+		time.Sleep(100 * time.Millisecond)
 	}
 }

--- a/examples/sdl2/main.go
+++ b/examples/sdl2/main.go
@@ -34,14 +34,14 @@ func main() {
 	}
 	defer sdl.Quit()
 
-	window, err := sdl.CreateWindow("go-ayame SDL2 example", sdl.WINDOWPOS_UNDEFINED, sdl.WINDOWPOS_UNDEFINED, WindowWidth, WindowHeight, sdl.WINDOW_SHOWN)
+	window, err := sdl.CreateWindow("go-ayame SDL2 example", sdl.WINDOWPOS_UNDEFINED, sdl.WINDOWPOS_UNDEFINED, WindowWidth, WindowHeight, sdl.WINDOW_SHOWN|sdl.WINDOW_ALLOW_HIGHDPI)
 	if err != nil {
 		log.Printf("Failed to create SDL window")
 		panic(err)
 	}
 	defer window.Destroy()
 
-	renderer, err := sdl.CreateRenderer(window, -1, 0)
+	renderer, err := sdl.CreateRenderer(window, -1, sdl.RENDERER_ACCELERATED)
 	if err != nil {
 		log.Printf("Failed to create SDL renderer")
 		panic(err)

--- a/examples/sdl2/main.go
+++ b/examples/sdl2/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"image"
 	"log"
 	"time"
 
@@ -13,8 +12,6 @@ import (
 	"github.com/pion/webrtc/v2"
 	"github.com/pion/webrtc/v2/pkg/media"
 	"github.com/veandco/go-sdl2/sdl"
-
-	"golang.org/x/image/draw"
 )
 
 func main() {
@@ -51,7 +48,7 @@ func main() {
 	}
 	defer renderer.Destroy()
 
-	texture, err := renderer.CreateTexture(sdl.PIXELFORMAT_ABGR8888, sdl.TEXTUREACCESS_STREAMING, WindowWidth, WindowHeight)
+	texture, err := renderer.CreateTexture(sdl.PIXELFORMAT_YV12, sdl.TEXTUREACCESS_STREAMING, WindowWidth, WindowHeight)
 	if err != nil {
 		log.Printf("Failed to create SDL texture")
 		panic(err)
@@ -117,24 +114,17 @@ func main() {
 					return
 				}
 
-				img := f.ToRGBA()
-				b := img.Bounds()
-				if b.Dx() == WindowWidth && b.Dy() == WindowHeight {
-					err = texture.Update(nil, img.Pix, WindowWidth*4)
-				} else {
-					dst := image.NewRGBA(image.Rect(0, 0, WindowWidth, WindowHeight))
-					draw.BiLinear.Scale(dst, dst.Bounds(), img, img.Bounds(), draw.Over, nil)
-					err = texture.Update(nil, dst.Pix, WindowWidth*4)
-				}
-
+				err = texture.UpdateYUV(nil, f.Plane(0), f.Stride(0), f.Plane(1), f.Stride(1), f.Plane(2), f.Stride(2))
 				if err != nil {
 					log.Println("Failed to update SDL Texture", err)
 					continue
 				}
 
-				window.UpdateSurface()
+				src := &sdl.Rect{0, 0, int32(f.Width()), int32(f.Height())}
+				dst := &sdl.Rect{0, 0, WindowWidth, WindowHeight}
+
 				renderer.Clear()
-				renderer.Copy(texture, nil, nil)
+				renderer.Copy(texture, src, dst)
 				renderer.Present()
 			}
 		}

--- a/pkg/vpx/vpx_decoder.go
+++ b/pkg/vpx/vpx_decoder.go
@@ -86,6 +86,35 @@ func (f *VpxFrame) Height() uint32 {
 	return uint32(f.image.d_h)
 }
 
+func (f *VpxFrame) Plane(n int) []byte {
+	var p *C.uchar
+
+	switch n {
+	case 0:
+		p = f.image.planes[C.VPX_PLANE_Y]
+	case 1:
+		p = f.image.planes[C.VPX_PLANE_U]
+	case 2:
+		p = f.image.planes[C.VPX_PLANE_V]
+	}
+
+	lenData := f.Width() * f.Height()
+	return (*[1 << 30]byte)(unsafe.Pointer(p))[:lenData:lenData]
+}
+
+func (f *VpxFrame) Stride(n int) int {
+	switch n {
+	case 0:
+		return int(f.image.stride[C.VPX_PLANE_Y])
+	case 1:
+		return int(f.image.stride[C.VPX_PLANE_U])
+	case 2:
+		return int(f.image.stride[C.VPX_PLANE_V])
+	default:
+		return -1
+	}
+}
+
 func (f *VpxFrame) ToBytes(format ColorFormat) []uint8 {
 	img := f.image
 	out := make([]uint8, img.d_w*img.d_h*4)


### PR DESCRIPTION
- [x] SDL の Main Loop に Sleep を仕込むことで、CPU利用率を低減する
- [x] YUV -> RGBA の変換を SDL 内部で実行してもらう。SDL 内部では SSE や GPU の支援をうけられるような実装になっているので、ソフトウェア処理より早い
- [x] SDL Window に描画時のスケーリング処理を SDL 側に移譲した。こちらも最適化がされているので、go で実装するより速い

結果として、CPU利用率が 110% -> 15% (ThinkPad E495 Ryzen 5 で計測時) にまで低減された。