### PR TITLE
[Breaking Change] DataChannel の API を変更

### DIFF
--- a/ayame/ayame.go
+++ b/ayame/ayame.go
@@ -66,7 +66,7 @@ func NewConnection(signalingURL string, roomID string, options *ConnectionOption
 		onDisconnectHandler:  func(reason string, err error) {},
 		onTrackPacketHandler: func(track *webrtc.Track, packet *rtp.Packet) {},
 		onByeHandler:         func() {},
-		onDataHandler:        func(dc *webrtc.DataChannel, msg *webrtc.DataChannelMessage) {},
+		onDataChannelHandler: func(dc *webrtc.DataChannel) {},
 	}
 
 	return c

--- a/ayame/connection.go
+++ b/ayame/connection.go
@@ -63,7 +63,7 @@ type Connection struct {
 	onDisconnectHandler  func(reason string, err error)
 	onTrackPacketHandler func(track *webrtc.Track, packet *rtp.Packet)
 	onByeHandler         func()
-	onDataHandler        func(dc *webrtc.DataChannel, msg *webrtc.DataChannelMessage)
+	onDataChannelHandler func(dc *webrtc.DataChannel)
 
 	callbackMu sync.Mutex
 }
@@ -102,11 +102,11 @@ func (c *Connection) Disconnect() {
 	c.onDisconnectHandler = func(reason string, err error) {}
 	c.onTrackPacketHandler = func(track *webrtc.Track, packet *rtp.Packet) {}
 	c.onByeHandler = func() {}
-	c.onDataHandler = func(dc *webrtc.DataChannel, msg *webrtc.DataChannelMessage) {}
+	c.onDataChannelHandler = func(dc *webrtc.DataChannel) {}
 }
 
-// AddDataChannel は指定した label と options から新しい DataChannel 作成して、追加します。
-func (c *Connection) AddDataChannel(label string, options *webrtc.DataChannelInit) (*webrtc.DataChannel, error) {
+// CreateDataChannel は指定した label と options から新しい DataChannel 作成して、追加します。
+func (c *Connection) CreateDataChannel(label string, options *webrtc.DataChannelInit) (*webrtc.DataChannel, error) {
 	if c.pc == nil {
 		return nil, fmt.Errorf("PeerConnection Does Not Ready")
 	}
@@ -117,29 +117,31 @@ func (c *Connection) AddDataChannel(label string, options *webrtc.DataChannelIni
 		return nil, fmt.Errorf("DataChannel Already Exists. label=%s", label)
 	}
 
-	dc, err := c.pc.CreateDataChannel(label, options)
-	if err != nil {
-		return nil, err
+	if c.isExistClient {
+		dc, err := c.pc.CreateDataChannel(label, options)
+		if err != nil {
+			return nil, err
+		}
+
+		dc.OnOpen(func() {
+			c.trace("datachannel OnOpen")
+		})
+		dc.OnClose(func() {
+			c.trace("datachannel OnClose")
+			delete(c.dataChannels, label)
+		})
+		dc.OnError(func(err error) {
+			c.trace("datachannel OnError: %v", err)
+			delete(c.dataChannels, label)
+		})
+		dc.OnMessage(func(msg webrtc.DataChannelMessage) {
+			c.trace("datachannel OnMessage")
+		})
+
+		c.dataChannels[label] = dc
+		return dc, nil
 	}
-
-	dc.OnOpen(func() {
-		c.trace("datachannel OnOpen")
-	})
-	dc.OnClose(func() {
-		c.trace("datachannel OnClose")
-		delete(c.dataChannels, label)
-	})
-	dc.OnError(func(err error) {
-		c.trace("datachannel OnError: %v", err)
-		delete(c.dataChannels, label)
-	})
-	dc.OnMessage(func(msg webrtc.DataChannelMessage) {
-		c.trace("datachannel OnMessage")
-		c.onDataHandler(dc, &msg)
-	})
-
-	c.dataChannels[label] = dc
-	return dc, nil
+	return nil, fmt.Errorf("client does not exist")
 }
 
 // OnOpen は open イベント発生時のコールバック関数を設定します。
@@ -177,11 +179,11 @@ func (c *Connection) OnBye(f func()) {
 	c.onByeHandler = f
 }
 
-// OnData は data イベント発生時のコールバック関数を設定します。
-func (c *Connection) OnData(f func(dc *webrtc.DataChannel, msg *webrtc.DataChannelMessage)) {
+// OnDataChannel は datachannel イベント発生時のコールバック関数を設定します。
+func (c *Connection) OnDataChannel(f func(dc *webrtc.DataChannel)) {
 	c.callbackMu.Lock()
 	defer c.callbackMu.Unlock()
-	c.onDataHandler = f
+	c.onDataChannelHandler = f
 }
 
 func (c *Connection) trace(format string, v ...interface{}) {
@@ -509,10 +511,13 @@ func (c *Connection) onDataChannel(dc *webrtc.DataChannel) {
 	})
 	dc.OnMessage(func(msg webrtc.DataChannelMessage) {
 		c.trace("datachannel OnMessage")
-		c.onDataHandler(dc, &msg)
 	})
 
-	c.dataChannels[label] = dc
+	if _, ok := c.dataChannels[label]; !ok {
+		c.dataChannels[label] = dc
+	}
+
+	c.onDataChannelHandler(dc)
 }
 
 func (c *Connection) closeDataChannel(dc *webrtc.DataChannel) {

--- a/ayame/connection.go
+++ b/ayame/connection.go
@@ -397,7 +397,7 @@ func (c *Connection) createPeerConnection() error {
 		c.onDataChannel(dc)
 	})
 
-	if c.pc != nil {
+	if c.pc == nil {
 		c.pc = pc
 		c.onOpenHandler(c.authzMetadata)
 	} else {

--- a/examples/gocv/main.go
+++ b/examples/gocv/main.go
@@ -61,11 +61,12 @@ func main() {
 		fmt.Println("Connected")
 
 		var err error = nil
-		dc, err = con.AddDataChannel("dataChannel1", nil)
+		dc, err = con.CreateDataChannel("dataChannel1", nil)
 		if err != nil {
-			log.Printf("AddDataChannel error: %v", err)
+			log.Printf("CreateDataChannel error: %v", err)
 			return
 		}
+		dc.OnMessage(onMessage(dc))
 	})
 
 	con.OnTrackPacket(func(track *webrtc.Track, packet *rtp.Packet) {
@@ -83,9 +84,10 @@ func main() {
 		}
 	})
 
-	con.OnData(func(c *webrtc.DataChannel, msg *webrtc.DataChannelMessage) {
-		if msg.IsString {
-			fmt.Printf("OnData[%s]: data=%s\n", c.Label(), (msg.Data))
+	con.OnDataChannel(func(c *webrtc.DataChannel) {
+		if dc == nil {
+			dc = c
+			dc.OnMessage(onMessage(dc))
 		}
 	})
 
@@ -177,6 +179,14 @@ L:
 			if window.WaitKey(1) == 27 {
 				break L
 			}
+		}
+	}
+}
+
+func onMessage(dc *webrtc.DataChannel) func(webrtc.DataChannelMessage) {
+	return func(msg webrtc.DataChannelMessage) {
+		if msg.IsString {
+			fmt.Printf("OnData[%s]: data=%s\n", dc.Label(), (msg.Data))
 		}
 	}
 }


### PR DESCRIPTION
ayame-web-sdk の仕様変更に追従 https://github.com/OpenAyame/ayame-web-sdk/pull/6

* webrtc.DataChannel オブジェクトをそのまま利用するように変更
  * webrtc.DataChannel オブジェクトを返す createDataChannel() を追加
  * webrtc.DataChannel オブジェクトをそのまま利用するため、不要になった addDataChannel()、on('data') コールバックを削除
* answer 側の datachannel イベントのための on('datachannel') コールバックの追加
* Ayame が isExistUser を送ってくる場合のみ接続できるように変更