### PR TITLE
AyameのURL変更に追従する

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ go-ayame を利用するには go 1.14 以上が必要です。
 ```go
 import "github.com/hakobera/go-ayame/ayame"
 
-signalingURL := "wss://ayame-lite.shiguredo.jp/signaling"
+signalingURL := "wss://ayame-labo.shiguredo.jp/signaling"
 roomID := "your_room_id"
 
 // ayame.Connect の作成

--- a/ayame/ayame_test.go
+++ b/ayame/ayame_test.go
@@ -59,7 +59,7 @@ func TestDefaultOptions(t *testing.T) {
 }
 
 func TestNewConnection(t *testing.T) {
-	signalingURL := "wss://ayame-lite.shiguredo.jp/signaling"
+	signalingURL := "wss://ayame-labo.shiguredo.jp/signaling"
 	roomID := "room1"
 	defaultOptions := ayame.DefaultOptions()
 

--- a/examples/datachannel/README.md
+++ b/examples/datachannel/README.md
@@ -1,6 +1,6 @@
 # save-to-webm (go-ayame 版)
 
-go-ayame と Pion、[Ayame Lite](https://ayame-lite.shiguredo.jp/beta) を使って、WebRTC P2P で DataChannel を使用したテキストデータのやりとりをするサンプルコードです。
+go-ayame と Pion、[Ayame Labo](https://ayame-labo.shiguredo.jp) を使って、WebRTC P2P で DataChannel を使用したテキストデータのやりとりをするサンプルコードです。
 
 ## 使い方
 
@@ -13,7 +13,7 @@ Ayame のオンラインサンプル [RTCDataChannel)](https://openayame.github.
 上記で入力した RoomID をコマンドラインパラメータとして指定します。
 
 ```console
-go run main.go -url wss://ayame-lite.shiguredo.jp/signaling -room-id <room-id>
+go run main.go -url wss://ayame-labo.shiguredo.jp/signaling -room-id <room-id>
 ```
 
 PeerConnection 接続が完了すると、コンソールに `Connected` と表示されます。

--- a/examples/datachannel/main.go
+++ b/examples/datachannel/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 func main() {
-	signalingURL := flag.String("url", "wss://ayame-lite.shiguredo.jp/signaling", "Specify Ayame service address")
+	signalingURL := flag.String("url", "wss://ayame-labo.shiguredo.jp/signaling", "Specify Ayame service address")
 	roomID := flag.String("room-id", "", "specify room ID")
 	signalingKey := flag.String("signaling-key", "", "specify signaling key")
 	verbose := flag.Bool("verbose", false, "enable verbose log")
@@ -25,7 +25,7 @@ func main() {
 
 	opts := ayame.DefaultOptions()
 	opts.SignalingKey = *signalingKey
-	
+
 	con := ayame.NewConnection(*signalingURL, *roomID, opts, *verbose, false)
 	defer con.Disconnect()
 

--- a/examples/gocv/README.md
+++ b/examples/gocv/README.md
@@ -1,6 +1,6 @@
 # GoCV
 
-go-ayame と Pion、libvpx、[Ayame Lite](https://ayame-lite.shiguredo.jp/beta) を使って、WebRTC P2P 経由で受け取った Video データを使ってモーション検知をし、検知した場合に DataChannel を利用して送信側にデータを送信するサンプルコードです。
+go-ayame と Pion、libvpx、[Ayame Labo](https://ayame-labo.shiguredo.jp) を使って、WebRTC P2P 経由で受け取った Video データを使ってモーション検知をし、検知した場合に DataChannel を利用して送信側にデータを送信するサンプルコードです。
 
 実際に動いている様子は以下のリンク先の Tweet の動画で確認できます。
 
@@ -75,7 +75,7 @@ void loop() {
 momo を以下のオプション付きで起動します。
  
 ```console
-$ momo --no-audio ayame wss://ayame-lite.shiguredo.jp/signaling <room-id> --serial /dev/<your-arduino-serial-device-name>,9600
+$ momo --no-audio ayame wss://ayame-labo.shiguredo.jp/signaling <room-id> --serial /dev/<your-arduino-serial-device-name>,9600
 ```
 
 ### gocv
@@ -83,5 +83,5 @@ $ momo --no-audio ayame wss://ayame-lite.shiguredo.jp/signaling <room-id> --seri
 momo の起動オプションでしていした RoomID をコマンドラインパラメータとして指定します。
 
 ```console
-go run . -url wss://ayame-lite.shiguredo.jp/signaling -room-id <room-id>
+go run . -url wss://ayame-labo.shiguredo.jp/signaling -room-id <room-id>
 ```

--- a/examples/gocv/main.go
+++ b/examples/gocv/main.go
@@ -24,7 +24,7 @@ const (
 var dc *webrtc.DataChannel = nil
 
 func main() {
-	signalingURL := flag.String("url", "wss://ayame-lite.shiguredo.jp/signaling", "Specify Ayame service address")
+	signalingURL := flag.String("url", "wss://ayame-labo.shiguredo.jp/signaling", "Specify Ayame service address")
 	roomID := flag.String("room-id", "", "specify room ID")
 	signalingKey := flag.String("signaling-key", "", "specify signaling key")
 	verbose := flag.Bool("verbose", false, "enable verbose log")

--- a/examples/save-to-webm/README.md
+++ b/examples/save-to-webm/README.md
@@ -1,6 +1,6 @@
 # save-to-webm (go-ayame 版)
 
-go-ayame と Pion、[Ayame Lite](https://ayame-lite.shiguredo.jp/beta) を使って、WebRTC P2P 経由で受け取った Video と Audio データを WebM 形式の動画ファイルとして保存するサンプルコードです。
+go-ayame と Pion、[Ayame Labo](https://ayame-labo.shiguredo.jp) を使って、WebRTC P2P 経由で受け取った Video と Audio データを WebM 形式の動画ファイルとして保存するサンプルコードです。
 
 このアプリケーションは [pion/example-webrtc-applications](https://github.com/pion/example-webrtc-applications) 中の [save-to-web](https://github.com/pion/example-webrtc-applications/tree/master/save-to-webm) のシグナリングの部分を go-ayame を利用するように変更したものです。
 
@@ -15,7 +15,7 @@ Ayame のオンラインサンプル [送信のみ(sendonly)](https://openayame.
 上記で入力した RoomID をコマンドラインパラメータとして指定します。
 
 ```console
-go run main.go -url wss://ayame-lite.shiguredo.jp/signaling -room-id <room-id>
+go run main.go -url wss://ayame-labo.shiguredo.jp/signaling -room-id <room-id>
 ```
 
 PeerConnection 接続が完了すると、コンソールに `Connected` と表示され、ブラウザからの送信された動画と音声データが実行したフォルダ内の `test.webm` という名前のファイルに保存されます。

--- a/examples/save-to-webm/main.go
+++ b/examples/save-to-webm/main.go
@@ -18,7 +18,7 @@ import (
 )
 
 func main() {
-	signalingURL := flag.String("url", "wss://ayame-lite.shiguredo.jp/signaling", "Specify Ayame service address")
+	signalingURL := flag.String("url", "wss://ayame-labo.shiguredo.jp/signaling", "Specify Ayame service address")
 	roomID := flag.String("room-id", "", "specify room ID")
 	signalingKey := flag.String("signaling-key", "", "specify signaling key")
 	verbose := flag.Bool("verbose", false, "enable verbose log")

--- a/examples/sdl2/README.md
+++ b/examples/sdl2/README.md
@@ -1,6 +1,6 @@
 # SDL2
 
-go-ayame と Pion、libvpx、[Ayame Lite](https://ayame-lite.shiguredo.jp/beta) を使って、WebRTC P2P 経由で受け取った Video データを [SDL2](https://www.libsdl.org/) を使って表示するサンプルコードです。
+go-ayame と Pion、libvpx、[Ayame Labo](https://ayame-labo.shiguredo.jp) を使って、WebRTC P2P 経由で受け取った Video データを [SDL2](https://www.libsdl.org/) を使って表示するサンプルコードです。
 
 ## 使い方
 
@@ -32,7 +32,7 @@ Ayame のオンラインサンプル [送信のみ(sendonly)](https://openayame.
 上記で入力した RoomID をコマンドラインパラメータとして指定します。
 
 ```console
-go run . -url wss://ayame-lite.shiguredo.jp/signaling -room-id <room-id>
+go run . -url wss://ayame-labo.shiguredo.jp/signaling -room-id <room-id>
 ```
 
 プログラムが開始されると、SDLのウィンドウが開き、PeerConnection 接続が完了すると、コンソールに `Connected` と表示されます。ブラウザからの送信された動画データは、初回キーフレームを受け取った後にSDLウィンドウ内に表示されます。
@@ -44,7 +44,7 @@ go run . -url wss://ayame-lite.shiguredo.jp/signaling -room-id <room-id>
 デフォルトでは VP8 形式の動画を受信するようになっていますが、このサンプルは VP9 形式の動画を受信することもできます。その場合、`-video-codec VP9` オプションを追加します。
 
 ```console
-go run . -url wss://ayame-lite.shiguredo.jp/signaling -room-id <room-id> -video-codec VP9
+go run . -url wss://ayame-labo.shiguredo.jp/signaling -room-id <room-id> -video-codec VP9
 ```
 
 ### 詳細ログを出力する
@@ -52,5 +52,5 @@ go run . -url wss://ayame-lite.shiguredo.jp/signaling -room-id <room-id> -video-
 詳細ログを出力する場合は、`-verbose` オプションを追加します。
 
 ```console
-go run . -url wss://ayame-lite.shiguredo.jp/signaling -room-id <room-id> -verbose
+go run . -url wss://ayame-labo.shiguredo.jp/signaling -room-id <room-id> -verbose
 ```

--- a/examples/sdl2/main.go
+++ b/examples/sdl2/main.go
@@ -19,7 +19,7 @@ const WindowWidth = 640
 const WindowHeight = 480
 
 func main() {
-	signalingURL := flag.String("url", "wss://ayame-lite.shiguredo.jp/signaling", "Specify Ayame service address")
+	signalingURL := flag.String("url", "wss://ayame-labo.shiguredo.jp/signaling", "Specify Ayame service address")
 	videoCodec := flag.String("video-codec", "VP8", "Specify video codec type [VP8 | VP9]")
 	roomID := flag.String("room-id", "", "specify room ID")
 	signalingKey := flag.String("signaling-key", "", "specify signaling key")


### PR DESCRIPTION
Ayameがbetaからlaboにバージョンが変わりドメインも変更となっています．
ドメインの変更に追従した修正になります．

`ayame-lite.shiguredo.jp`
-> `ayame-labo.shiguredo.jp`