### PR TITLE
fix: handle error on signalling properly

### DIFF
--- a/ayame/connection.go
+++ b/ayame/connection.go
@@ -74,7 +74,10 @@ func (c *Connection) Connect() error {
 		c.trace("connection already exists")
 		return fmt.Errorf("connection alreay exists")
 	}
-	c.signaling()
+	err := c.signaling()
+	if err != nil {
+		return fmt.Errorf("signaling error: %w", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Properly handle error on signalling. 
With conventional code, the signalling error (such as connection error to ayame) can't be handled from application code.